### PR TITLE
Add support for lower/mixed case FASTA

### DIFF
--- a/deepsp_predictor.py
+++ b/deepsp_predictor.py
@@ -165,6 +165,7 @@ X = seq_list
 
 # One Hot Encoding of Aligned Sequence
 def one_hot_encoder(s):
+    s = s.upper()
     d = {'A': 0, 'C': 1, 'D': 2, 'E': 3, 'F': 4, 'G': 5, 'H': 6, 'I': 7, 'K': 8, 'L': 9, 'M': 10, 'N': 11, 'P': 12, 'Q': 13, 'R': 14, 'S': 15, 'T': 16, 'V': 17, 'W': 18, 'Y': 19, '-': 20}
 
     x = np.zeros((len(d), len(s)))


### PR DESCRIPTION
FASTA format is not limited to only the UPPERCASE letters. Sometimes a dataset even comes with mixed-case sequences (designating insertions)

Also apparently I've automatically added [a missing line-break](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206) before EOF
(a line without a trailing line break is formally "not a line")